### PR TITLE
Register before the nativeSourceHandler

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -219,7 +219,7 @@
       handleSource: function (source, tech) {
         return new Html5DashJS(source, tech);
       }
-    });
+    }, 0);
   }
 
   videojs.Html5DashJS = Html5DashJS;


### PR DESCRIPTION
Edge browser supports native DASH but has limited support. Place ourselves before the nativeSourceHandler to get first-shot at playing back DASH content

Should fix #14