### PR TITLE
Update deprecated `laURL` to utilize new `serverURL`.

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -144,7 +144,7 @@
    * Iterate over the `keySystemOptions` array and convert each object into
    * the type of object Dash.js expects in the `protData` argument.
    *
-   * Also rename 'licenseUrl' property in the options to an 'laURL' property
+   * Also rename 'licenseUrl' property in the options to an 'serverURL' property
    */
   Html5DashJS.buildDashJSProtData = function (keySystemOptions) {
     var
@@ -162,7 +162,7 @@
       options = mergeOptions({}, keySystem.options);
 
       if (options.licenseUrl) {
-        options.laURL = options.licenseUrl;
+        options.serverURL = options.licenseUrl;
         delete options.licenseUrl;
       }
 

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -160,8 +160,8 @@
 
     var empty = videojs.Html5DashJS.buildDashJSProtData(undefined);
 
-    strictEqual(output['com.widevine.alpha'].laURL, 'https://example.com/license',
-      'licenceUrl converted to laURL');
+    strictEqual(output['com.widevine.alpha'].serverURL, 'https://example.com/license',
+      'licenceUrl converted to serverURL');
     deepEqual(empty, {}, 'undefined keySystemOptions returns empty object');
   });
 
@@ -175,7 +175,7 @@
       mergedKeySystemOptions = {
         'com.widevine.alpha': {
           extra: 'data',
-          laURL:'https://example.com/license'
+          serverURL:'https://example.com/license'
         }
       };
 


### PR DESCRIPTION
See: https://groups.google.com/forum/#!topic/dashjs/jQ0B5Q-xOlw

Figured I would create this PR while it is in my mind. There is mention that `Dash.js#1.5.0` will be targeted for `Sep 8, 2015`.

https://github.com/Dash-Industry-Forum/dash.js/blob/69eb95361357cc17613e81f097f8742b09f12cc0/src/streaming/controllers/ProtectionController.js#L241

Anyways, this is minor, but is **BLOCKED** until they release `1.5`.

On the bright side, pointing at the `Dash.js#development`, currently, with `videojs-contrib-dash` seems to be working nicely.

---

Edit: https://twitter.com/DASH_IF/status/641568765998727169