### PR TITLE
Add space before vjs-dashjs-hide-errors in className

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -124,7 +124,7 @@
    * to reset MediaKeys in resetSrc_
    */
   Html5DashJS.hideErrors = function (el) {
-    el.className += 'vjs-dashjs-hide-errors';
+    el.className += ' vjs-dashjs-hide-errors';
   };
 
   /*
@@ -136,7 +136,7 @@
     // 250ms is arbitrary but I haven't seen dash.js take longer than that to initialize
     // in my testing
     setTimeout(function () {
-      el.className = el.className.replace('vjs-dashjs-hide-errors', '');
+      el.className = el.className.replace(' vjs-dashjs-hide-errors', '');
     }, 250);
   };
 


### PR DESCRIPTION
This separates "vjs-dashjs-hide-errors" from previously assigned classes on the element. 
Right now it's impossible to remove the last added class using VideoJS.removeClass because:
1) elmVideo.className = 'foo bar'
2) Html5DashJS.hideErrors() runs
3) elmVideo.className is now 'foo barvjs-dashjs-hide-errors'
4) VideoJS.removeClass('bar') looks for ' bar ', cannot find it and doesn't remove it
