### PR TITLE
Clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-watch": "~0.4.0",
     "load-grunt-tasks": "^3.1.0",
     "qunitjs": "^1.17.1",
-    "video.js": "^5.0.0-rc.70",
-    "videojs-automation": "^0.3.1"
+    "video.js": "^5.0.0",
+    "videojs-automation": "0.3.1"
   }
 }


### PR DESCRIPTION
Use an exact version of videojs-automation and bump up the minimum video.js package to 5.0.0.