### PR TITLE
Add canPlayType

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -221,7 +221,7 @@
       canPlayType: function (type) {
         return videojs.DashSourceHandler.canPlayType(type);
       }
-    }
+    };
   };
 
   videojs.DashSourceHandler.canPlayType = function (type) {

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -200,14 +200,12 @@
     this.resetSrc_(function noop(){});
   };
 
-  // Only add the SourceHandler if the browser supports MediaSourceExtensions
-  if (!!window.MediaSource) {
-    videojs.getComponent('Html5').registerSourceHandler({
+  videojs.DashSourceHandler = function() {
+    return {
       canHandleSource: function (source) {
-        var dashTypeRE = /^application\/dash\+xml/i;
         var dashExtRE = /\.mpd/i;
 
-        if (dashTypeRE.test(source.type)) {
+        if (videojs.DashSourceHandler.canPlayType(source.type)) {
           return 'probably';
         } else if (dashExtRE.test(source.src)){
           return 'maybe';
@@ -218,8 +216,26 @@
 
       handleSource: function (source, tech) {
         return new Html5DashJS(source, tech);
+      },
+
+      canPlayType: function (type) {
+        return videojs.DashSourceHandler.canPlayType(type);
       }
-    }, 0);
+    }
+  };
+
+  videojs.DashSourceHandler.canPlayType = function (type) {
+    var dashTypeRE = /^application\/dash\+xml/i;
+    if (dashTypeRE.test(type)) {
+      return 'probably';
+    }
+
+    return '';
+  };
+
+  // Only add the SourceHandler if the browser supports MediaSourceExtensions
+  if (!!window.MediaSource) {
+    videojs.getComponent('Html5').registerSourceHandler(videojs.DashSourceHandler(), 0);
   }
 
   videojs.Html5DashJS = Html5DashJS;

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -143,6 +143,11 @@
       'canHandleSource with expected extension returns "maybe"');
     strictEqual(dashSourceHandler.canHandleSource(nonDashSource), '',
       'canHandleSource with anything else returns ""');
+
+    strictEqual(dashSourceHandler.canPlayType(dashSource.type), 'probably',
+      'canPlayType with proper mime-type returns "probably"');
+    strictEqual(dashSourceHandler.canPlayType(nonDashSource.type), '',
+      'canPlayType with anything else returns ""');
   });
 
   test('validate buildDashJSProtData function', function() {


### PR DESCRIPTION
A few months ago I added `canPlayType` to the sourcehandlers spec in video.js.

However, this plugin did not use that yet, so I have added it.

I based the code on the HLS plugin, so maybe there are some things that should be done differently, please tell me :).