### PR TITLE
Set dash.js 1.6.0 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "MPEG-DASH"
   ],
   "devDependencies": {
-    "dashjs": "git://github.com/Dash-Industry-Forum/dash.js",
+    "dashjs": "git://github.com/Dash-Industry-Forum/dash.js#v1.6.0",
     "grunt": "~0.4.1",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "~0.4.0",


### PR DESCRIPTION
Dash.js 2.0 is using ES6 without producing a browserified dist file which will mess up our tests. This PR specifies dash.js 1.6.0 until dash.js 2.0 is supported (see #38) 