### PR TITLE
Only use browserify-shim when building dist files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,9 @@ module.exports = function(grunt) {
       dist: {
         files: {
           'tmp/videojs-dash.js': ['src/js/videojs-dash.js']
+        },
+        options: {
+          transform: ['browserify-shim']
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,22 +24,17 @@
     "dash",
     "MPEG-DASH"
   ],
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
   "browserify-shim": {
     "dashjs": "global:dashjs",
     "video.js": "global:videojs"
   },
   "dependencies": {
-    "browserify-shim": "^3.8.12",
     "dashjs": "^2.0.0",
     "global": "^4.3.0",
     "video.js": "^5.0.0"
   },
   "devDependencies": {
+    "browserify-shim": "^3.8.12",
     "grunt": "~0.4.1",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
Similar to https://github.com/brightcove/videojs-playlist/pull/44, this allows a user to import contrib-dash without setting video.js and dash.js to window first.