### PR TITLE
Allow to pass option to limit bitrate by portal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ videojs.Html5DashJS.updateSourceData = function(source) {
 
 It is possible to pass options to Dash.js during initialiation of video.js. The following options are currently supported:
 
-* `limit_bitrate_by_portal` (defaults to `false`): if set to `true`, Dash.js will not request video tracks which are bigger than the video element.
+* `limitBitrateByPortal` (defaults to `false`): if set to `true`, Dash.js will not request video tracks which are bigger than the video element.
 
 To set these options, pass them in the `html5.dash` object of video.js during initialization.
 
@@ -83,7 +83,7 @@ For example:
 var player = videojs('example-video', {
   html5: {
     dash: {
-      limit_bitrate_by_portal: true
+      limitBitrateByPortal: true
     }
   }
 });

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ videojs.Html5DashJS.updateSourceData = function(source) {
 };
 ```
 
+## Passing options to Dash.js
+
+It is possible to pass options to Dash.js during initialiation of video.js. The following options are currently supported:
+
+* `limit_bitrate_by_portal` (defaults to `false`): if set to `true`, Dash.js will not request video tracks which are bigger than the video element.
+
+To set these options, pass them in the `html5.dash` object of video.js during initialization.
+
+For example:
+
+```javascript
+var player = videojs('example-video', {
+  html5: {
+    dash: {
+      limit_bitrate_by_portal: true
+    }
+  }
+});
+```
+
 ## Before Initialize Hook
 
 Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases we have a beforeInitialize hook. The method is passed the Video.js player instance and the instance of Dash.js' MediaPlayer we are using, before the media player is initialized.

--- a/example.html
+++ b/example.html
@@ -30,7 +30,13 @@
     videoEl.className = 'video-js vjs-default-skin';
     fixture.appendChild(videoEl);
 
-    var player = videojs('vid');
+    var player = videojs('vid', {
+      html5: {
+        dash: {
+          limit_bitrate_by_portal: true
+        }
+      }
+    });
 
     player.ready(function() {
       player.src({

--- a/example.html
+++ b/example.html
@@ -33,7 +33,7 @@
     var player = videojs('vid', {
       html5: {
         dash: {
-          limit_bitrate_by_portal: true
+          limitBitrateByPortal: true
         }
       }
     });

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -13,8 +13,10 @@ let
  * Use Dash.js to playback DASH content inside of Video.js via a SourceHandler
  */
 class Html5DashJS {
-  constructor(source, tech) {
-    let options = tech.options_;
+  constructor(source, tech, options) {
+    // Get options from tech if not provided for backwards compatibility
+    options = options || tech.options_;
+
     let player = videojs(options.playerId);
 
     this.tech_ = tech;
@@ -60,6 +62,14 @@ class Html5DashJS {
     // Must run controller before these two lines or else there is no
     // element to bind to.
     this.mediaPlayer_.initialize();
+    
+    // Apply any options that are set
+    if (options.dash && options.dash.limit_bitrate_by_portal) {
+      this.mediaPlayer_.setLimitBitrateByPortal(true);
+    } else {
+      this.mediaPlayer_.setLimitBitrateByPortal(false);
+    }
+    
     this.mediaPlayer_.attachView(this.el_);
 
     // Dash.js autoplays by default, video.js will handle autoplay
@@ -121,8 +131,8 @@ videojs.DashSourceHandler = function() {
       }
     },
 
-    handleSource: function(source, tech) {
-      return new Html5DashJS(source, tech);
+    handleSource: function(source, tech, options) {
+      return new Html5DashJS(source, tech, options);
     },
 
     canPlayType: function(type) {

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -64,7 +64,7 @@ class Html5DashJS {
     this.mediaPlayer_.initialize();
     
     // Apply any options that are set
-    if (options.dash && options.dash.limit_bitrate_by_portal) {
+    if (options.dash && options.dash.limitBitrateByPortal) {
       this.mediaPlayer_.setLimitBitrateByPortal(true);
     } else {
       this.mediaPlayer_.setLimitBitrateByPortal(false);

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -65,7 +65,7 @@
       options = {
         playerId: el.getAttribute('id'),
         dash: {
-          limit_bitrate_by_portal: limitBitrateByPortal
+          limitBitrateByPortal: limitBitrateByPortal
         }
       };
       tech.el = function() { return el; };


### PR DESCRIPTION
This adds a way to pass options to dash.js using video.js options.

Because the new way (passing `options` to `handleSource`) is new in video.js 5.10, I've made it backwards compatible with video.js 5.9 and lower by still using `tech.options_` if not set. At some point we should probably remove this.

Currently the only option I've added is the "limit bitrate by portal size" option.

Note that the before initialize hook can not be used for these options, as they should be done after initializing.

I also modified / added tests to test for this new feature.