### PR TITLE
Expose mediaplayer on player

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -62,14 +62,14 @@ class Html5DashJS {
     // Must run controller before these two lines or else there is no
     // element to bind to.
     this.mediaPlayer_.initialize();
-    
+
     // Apply any options that are set
     if (options.dash && options.dash.limitBitrateByPortal) {
       this.mediaPlayer_.setLimitBitrateByPortal(true);
     } else {
       this.mediaPlayer_.setLimitBitrateByPortal(false);
     }
-    
+
     this.mediaPlayer_.attachView(this.el_);
 
     // Dash.js autoplays by default, video.js will handle autoplay

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -17,8 +17,8 @@ class Html5DashJS {
     // Get options from tech if not provided for backwards compatibility
     options = options || tech.options_;
 
-    let player = videojs(options.playerId);
-    player.dash = player.dash || {};
+    this.player = videojs(options.playerId);
+    this.player.dash = this.player.dash || {};
 
     this.tech_ = tech;
     this.el_ = tech.el();
@@ -41,9 +41,9 @@ class Html5DashJS {
     let manifestSource = source.src;
     this.keySystemOptions_ = Html5DashJS.buildDashJSProtData(source.keySystemOptions);
 
-    player.dash.mediaPlayer = dashjs.MediaPlayer().create();
+    this.player.dash.mediaPlayer = dashjs.MediaPlayer().create();
 
-    this.mediaPlayer_ = player.dash.mediaPlayer;
+    this.mediaPlayer_ = this.player.dash.mediaPlayer;
 
     // Log MedaPlayer messages through video.js
     if (Html5DashJS.useVideoJSDebug) {
@@ -53,7 +53,7 @@ class Html5DashJS {
     }
 
     if (Html5DashJS.beforeInitialize) {
-      Html5DashJS.beforeInitialize(player, this.mediaPlayer_);
+      Html5DashJS.beforeInitialize(this.player, this.mediaPlayer_);
     }
 
     // Must run controller before these two lines or else there is no
@@ -110,6 +110,10 @@ class Html5DashJS {
   dispose() {
     if (this.mediaPlayer_) {
       this.mediaPlayer_.reset();
+    }
+
+    if (this.player.dash) {
+      delete this.player.dash;
     }
   }
 }

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -18,6 +18,7 @@ class Html5DashJS {
     options = options || tech.options_;
 
     let player = videojs(options.playerId);
+    player.dash = player.dash || {};
 
     this.tech_ = tech;
     this.el_ = tech.el();
@@ -40,13 +41,9 @@ class Html5DashJS {
     let manifestSource = source.src;
     this.keySystemOptions_ = Html5DashJS.buildDashJSProtData(source.keySystemOptions);
 
-    // Save the context after the first initialization for subsequent instances
-    Html5DashJS.context_ = Html5DashJS.context_ || {};
+    player.dash.mediaPlayer = dashjs.MediaPlayer().create();
 
-    // reuse MediaPlayer if it already exists
-    if (!this.mediaPlayer_) {
-      this.mediaPlayer_ = dashjs.MediaPlayer(Html5DashJS.context_).create();
-    }
+    this.mediaPlayer_ = player.dash.mediaPlayer;
 
     // Log MedaPlayer messages through video.js
     if (Html5DashJS.useVideoJSDebug) {

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -21,19 +21,17 @@
       var
         startupCalled = false,
         attachViewCalled = false,
-        resetSrcCalled = false,
         setLimitBitrateByPortalCalled = false,
         setLimitBitrateByPortalValue = null,
         el = document.createElement('div'),
-        parentEl = document.createElement('div'),
+        fixture = document.querySelector('#qunit-fixture'),
         Html5,
         tech,
         options,
 
         //stubs
         origMediaPlayer = dashjs.MediaPlayer,
-        origVJSXHR = videojs.xhr,
-        origResetSrc = videojs.Html5DashJS.prototype.resetSrc_;
+        origVJSXHR = videojs.xhr;
 
       assert.expect(7);
 
@@ -41,8 +39,7 @@
       limitBitrateByPortal = limitBitrateByPortal || false;
 
       el.setAttribute('id', 'test-vid');
-      parentEl.appendChild(el);
-      document.body.appendChild(parentEl);
+      fixture.appendChild(el);
 
       Html5 = videojs.getComponent('Html5');
       tech = new Html5({
@@ -54,11 +51,8 @@
           limitBitrateByPortal: limitBitrateByPortal
         }
       };
-      tech.el = function() {
-        return el;
-      };
-      tech.triggerReady = function() {};
-      parentEl.appendChild(el);
+      tech.el = function() { return el; };
+      tech.triggerReady = function() { };
 
       dashjs.MediaPlayer = function() {
         return {
@@ -93,7 +87,6 @@
                 // Restore
                 dashjs.MediaPlayer = origMediaPlayer;
                 videojs.xhr = origVJSXHR;
-                videojs.Html5DashJS.prototype.resetSrc_ = origResetSrc;
               },
 
               setLimitBitrateByPortal: function(value) {
@@ -103,12 +96,6 @@
             };
           }
         };
-      };
-
-      // We have to override this because PhantomJS does not have Encrypted Media Extensions
-      videojs.Html5DashJS.prototype.resetSrc_ = function(fn) {
-        resetSrcCalled = true;
-        return fn();
       };
 
       var dashSourceHandler = Html5.selectSourceHandler(source);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -44,7 +44,6 @@
     },
     afterEach: function() {
       this.player.dispose();
-      this.fixture.innerHTML = '';
     }
   });
 


### PR DESCRIPTION
This PR is to place the dashjs mediaplayer on player.dash.mediaPlayer. The media player will be recreated every time a source is loaded in the video.js player.