### PR TITLE
add option to hide captions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ It is possible to pass options to Dash.js during initialiation of video.js. The 
 
 * `limitBitrateByPortal` (defaults to `false`): if set to `true`, Dash.js will not request video tracks which are bigger than the video element.
 
+* `hideCaptions` (defaults to `false`): if set to `true`, Dash.js will not show captions that are passed through by the manifest
+
 To set these options, pass them in the `html5.dash` object of video.js during initialization.
 
 For example:

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -61,10 +61,19 @@ class Html5DashJS {
     this.mediaPlayer_.initialize();
 
     // Apply any options that are set
-    if (options.dash && options.dash.limitBitrateByPortal) {
-      this.mediaPlayer_.setLimitBitrateByPortal(true);
-    } else {
-      this.mediaPlayer_.setLimitBitrateByPortal(false);
+    if (options.dash) {
+      if (options.dash.limitBitrateByPortal) {
+        this.mediaPlayer_.setLimitBitrateByPortal(true);
+      } else {
+        this.mediaPlayer_.setLimitBitrateByPortal(false);
+      }
+      if (options.dash.hideCaptions) {
+        this.mediaPlayer_.on(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED,
+          function() {
+            this.mediaPlayer_.setTextTrack(-1);
+          }
+        );
+      }
     }
 
     this.mediaPlayer_.attachView(this.el_);


### PR DESCRIPTION
This adds an option to hide captions that are passed through since they are not handled correctly at the moment

ref: https://github.com/videojs/videojs-contrib-dash/issues/103