### PR TITLE
Exposure canHandleSource

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -121,15 +121,7 @@ class Html5DashJS {
 videojs.DashSourceHandler = function() {
   return {
     canHandleSource: function(source) {
-      let dashExtRE = /\.mpd/i;
-
-      if (videojs.DashSourceHandler.canPlayType(source.type)) {
-        return 'probably';
-      } else if (dashExtRE.test(source.src)) {
-        return 'maybe';
-      } else {
-        return '';
-      }
+      return videojs.DashSourceHandler.canHandleSource(source);
     },
 
     handleSource: function(source, tech, options) {
@@ -149,6 +141,18 @@ videojs.DashSourceHandler.canPlayType = function(type) {
   }
 
   return '';
+};
+
+videojs.DashSourceHandler.canHandleSource = function(source) {
+  let dashExtRE = /\.mpd/i;
+
+  if (videojs.DashSourceHandler.canPlayType(source.type)) {
+    return 'probably';
+  } else if (dashExtRE.test(source.src)) {
+    return 'maybe';
+  } else {
+    return '';
+  }
 };
 
 // Only add the SourceHandler if the browser supports MediaSourceExtensions


### PR DESCRIPTION
This is to allow `videojs.DashSourceHandler.canHandleSource` to be overridden.