### PR TITLE
Don't pass empty object for key systems.

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -89,7 +89,7 @@ class Html5DashJS {
     let output = {};
 
     if (!keySystemOptions || !isArray(keySystemOptions)) {
-      return output;
+      return null;
     }
 
     for (let i = 0; i < keySystemOptions.length; i++) {

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -145,7 +145,7 @@
 
     assert.strictEqual(output['com.widevine.alpha'].serverURL, 'https://example.com/license',
       'licenceUrl converted to serverURL');
-    assert.deepEqual(empty, {}, 'undefined keySystemOptions returns empty object');
+    assert.equal(empty, null, 'undefined keySystemOptions returns null');
   });
 
   q.test('validate handleSource function with src-provided key options', function(assert) {
@@ -171,7 +171,7 @@
   });
 
   q.test('validate handleSource function with invalid manifest', function(assert) {
-    var mergedKeySystemOptions = {};
+    var mergedKeySystemOptions = null;
 
     testHandleSource(assert, sampleSrcNoDRM, mergedKeySystemOptions);
   });


### PR DESCRIPTION
Dash.js interprets an empty object as disallowing all DRM key systems.
Undefined or null are treated as no options.

Switch to using null so we get the default no options behavior here.