### PR TITLE
Allow for multiple beforeInitialize hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ var player = videojs('example-video', {
 });
 ```
 
-## Before Initialize Hook
+## Initialization Hook
 
-Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases we have a beforeInitialize hook. The method takes a callback that is passed the Video.js player instance and the instance of Dash.js' MediaPlayer we are using, before the media player is initialized.
+Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases we have an api `registerInitializationHook`. The method takes a callback that is passed the Video.js player instance and the instance of Dash.js' MediaPlayer we are using, before the media player is initialized.
 
 ```javascript
 var myCustomCallback = function(player, mediaPlayer) {
@@ -110,5 +110,5 @@ var myCustomCallback = function(player, mediaPlayer) {
   }
 };
 
-videojs.Html5DashJS.beforeInitialize(myCustomCallback);
+videojs.Html5DashJS.registerInitializationHook(myCustomCallback);
 ```

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ player.src({
 });
 ```
 
-You may also manipulate the source object by setting the `videojs.Html5DashJS.updateSourceData` function. This function takes a source object as an argument and should return a source object.
+You may also manipulate the source object by registering a function to the `updatesource` hook. Your function should take a source object as an argument and should return a source object.
 
 ```javascript
-videojs.Html5DashJS.updateSourceData = function(source) {
+var updateSourceData = function(source) {
   source.keySystemOptions = [{
     name: 'com.widevine.alpha',
     options: {
@@ -73,6 +73,8 @@ videojs.Html5DashJS.updateSourceData = function(source) {
   }];
   return source;
 };
+
+videojs.Html5DashJS.hook('updatesource', updateSourceData);
 ```
 
 ## Passing options to Dash.js
@@ -97,7 +99,11 @@ var player = videojs('example-video', {
 
 ## Initialization Hook
 
-Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases we have an api `registerInitializationHook`. The method takes a callback that is passed the Video.js player instance and the instance of Dash.js' MediaPlayer we are using, before the media player is initialized.
+Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases, you can register a function to the `beforeinitialize` hook, which will be called just before the Dash.js MediaPlayer is initialized.
+
+Your function should have two parameters:
+ 1. The video.js Player instance
+ 2. The Dash.js MediaPlayer instance
 
 ```javascript
 var myCustomCallback = function(player, mediaPlayer) {
@@ -110,5 +116,5 @@ var myCustomCallback = function(player, mediaPlayer) {
   }
 };
 
-videojs.Html5DashJS.registerInitializationHook(myCustomCallback);
+videojs.Html5DashJS.hook('beforeinitialize', myCustomCallback);
 ```

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ var player = videojs('example-video', {
 
 ## Before Initialize Hook
 
-Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases we have a beforeInitialize hook. The method is passed the Video.js player instance and the instance of Dash.js' MediaPlayer we are using, before the media player is initialized.
+Sometimes you may need to extend Dash.js, or have access to the Dash.js MediaPlayer before it is initialized. For these cases we have a beforeInitialize hook. The method takes a callback that is passed the Video.js player instance and the instance of Dash.js' MediaPlayer we are using, before the media player is initialized.
 
 ```javascript
-videojs.Html5DashJS.beforeInitialize = function(player, mediaPlayer) {
+var myCustomCallback = function(player, mediaPlayer) {
   // Log MediaPlayer messages through video.js
   if (videojs && videojs.log) {
     mediaPlayer.getDebug().setLogToBrowserConsole(false);
@@ -109,4 +109,6 @@ videojs.Html5DashJS.beforeInitialize = function(player, mediaPlayer) {
     });
   }
 };
+
+videojs.Html5DashJS.beforeInitialize(myCustomCallback);
 ```

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -52,9 +52,9 @@ class Html5DashJS {
       Html5DashJS.useVideoJSDebug(this.mediaPlayer_);
     }
 
-    if (Html5DashJS.beforeInitialize) {
-      Html5DashJS.beforeInitialize(this.player, this.mediaPlayer_);
-    }
+    Html5DashJS.beforeInitializeHooks_.forEach((hook) => {
+      hook(this.player, this.mediaPlayer_);
+    });
 
     // Must run controller before these two lines or else there is no
     // element to bind to.
@@ -115,8 +115,28 @@ class Html5DashJS {
     if (this.player.dash) {
       delete this.player.dash;
     }
+
+    Html5DashJS.beforeInitializeHooks_.length = 0;
+  }
+
+  /**
+   * Registers a callback function to be called before the MediaPlayer is initialized.
+   * Does not register duplicates
+   *
+   * @param {Function} fn callback function to register
+   * @function beforeInitialize
+   */
+  static beforeInitialize(fn) {
+    const index = Html5DashJS.beforeInitializeHooks_.indexOf(fn);
+
+    if (index <= -1) {
+      // Only add callback if its not a duplicate
+      Html5DashJS.beforeInitializeHooks_.push(fn);
+    }
   }
 }
+
+Html5DashJS.beforeInitializeHooks_ = [];
 
 const canHandleKeySystems = function(source) {
   if (Html5DashJS.updateSourceData) {

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -48,8 +48,14 @@ class Html5DashJS {
     // Log MedaPlayer messages through video.js
     if (Html5DashJS.useVideoJSDebug) {
       videojs.log.warn('useVideoJSDebug has been deprecated.' +
-        ' Please switch to using beforeInitialize.');
+        ' Please switch to using registerInitializationHook.');
       Html5DashJS.useVideoJSDebug(this.mediaPlayer_);
+    }
+
+    if (Html5DashJS.beforeInitialize) {
+      videojs.log.warn('beforeInitialize has been deprecated.' +
+        ' Please switch to using registerInitializationHook.');
+      Html5DashJS.beforeInitialize(this.player, this.mediaPlayer_);
     }
 
     Html5DashJS.beforeInitializeHooks_.forEach((hook) => {
@@ -122,9 +128,9 @@ class Html5DashJS {
    * Does not register duplicates
    *
    * @param {Function} fn callback function to register
-   * @function beforeInitialize
+   * @function registerInitializationHook
    */
-  static beforeInitialize(fn) {
+  static registerInitializationHook(fn) {
     const index = Html5DashJS.beforeInitializeHooks_.indexOf(fn);
 
     if (index <= -1) {

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -115,8 +115,6 @@ class Html5DashJS {
     if (this.player.dash) {
       delete this.player.dash;
     }
-
-    Html5DashJS.beforeInitializeHooks_.length = 0;
   }
 
   /**

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -35,8 +35,15 @@ class Html5DashJS {
     tech.isReady_ = false;
 
     if (Html5DashJS.updateSourceData) {
+      videojs.log.warn('updateSourceData has been deprecated.' +
+        ' Please switch to using hook("updatesource", callback).');
       source = Html5DashJS.updateSourceData(source);
     }
+
+    // call updatesource hooks
+    Html5DashJS.hooks('updatesource').forEach((hook) => {
+      source = hook(source);
+    });
 
     let manifestSource = source.src;
     this.keySystemOptions_ = Html5DashJS.buildDashJSProtData(source.keySystemOptions);
@@ -48,17 +55,17 @@ class Html5DashJS {
     // Log MedaPlayer messages through video.js
     if (Html5DashJS.useVideoJSDebug) {
       videojs.log.warn('useVideoJSDebug has been deprecated.' +
-        ' Please switch to using registerInitializationHook.');
+        ' Please switch to using hook("beforeinitialize", callback).');
       Html5DashJS.useVideoJSDebug(this.mediaPlayer_);
     }
 
     if (Html5DashJS.beforeInitialize) {
       videojs.log.warn('beforeInitialize has been deprecated.' +
-        ' Please switch to using registerInitializationHook.');
+        ' Please switch to using hook("beforeinitialize", callback).');
       Html5DashJS.beforeInitialize(this.player, this.mediaPlayer_);
     }
 
-    Html5DashJS.initializationHooks_.forEach((hook) => {
+    Html5DashJS.hooks('beforeinitialize').forEach((hook) => {
       hook(this.player, this.mediaPlayer_);
     });
 
@@ -124,43 +131,57 @@ class Html5DashJS {
   }
 
   /**
-   * Registers a callback function to be called before the MediaPlayer is initialized.
-   * Does not register duplicates
+   * Get a list of hooks for a specific lifecycle
    *
-   * @param {Function} hook callback function to register
-   * @function registerInitializationHook
+   * @param {string} type the lifecycle to get hooks from
+   * @param {Function=|Function[]=} hook Optionally add a hook tothe lifecycle
+   * @return {Array} an array of hooks or epty if none
+   * @method hooks
    */
-  static registerInitializationHook(hook) {
-    const index = Html5DashJS.initializationHooks_.indexOf(hook);
+  static hooks(type, hook) {
+    Html5DashJS.hooks_[type] = Html5DashJS.hooks_[type] || [];
 
-    if (index === -1) {
-      // Only add callback if its not a duplicate
-      Html5DashJS.initializationHooks_ = Html5DashJS.initializationHooks_.concat(hook);
+    if (hook) {
+      Html5DashJS.hooks_[type] = Html5DashJS.hooks_[type].concat(hook);
     }
+
+    return Html5DashJS.hooks_[type];
+  }
+
+/**
+ * Add a function hook to a specific dash lifecycle
+ *
+ * @param {string} type the lifecycle to hook the function to
+ * @param {Function|Function[]} hook the function or array of functions to attach
+ * @method hook
+ */
+  static hook(type, hook) {
+    Html5DashJS.hooks(type, hook);
   }
 
   /**
-   * Removes a registered callback function from the initialization hooks.
+   * Remove a hook from a specific dash lifecycle.
    *
-   * @param {Function} hook callback function to remove
-   * @return {boolean} true if removed, false if callback not registered
-   * @function removeInitializationHook
+   * @param {string} type the lifecycle that the function hooked to
+   * @param {Function} hook The hooked function to remove
+   * @return {boolean} True if the function was removed, false if not found
+   * @method removeHook
    */
-  static removeInitializationHook(hook) {
-    const index = Html5DashJS.initializationHooks_.indexOf(hook);
+  static removeHook(type, hook) {
+    const index = Html5DashJS.hooks(type).indexOf(hook);
 
-    if (index !== -1) {
-      Html5DashJS.initializationHooks_ = Html5DashJS.initializationHooks_.slice();
-      Html5DashJS.initializationHooks_.splice(index, 1);
-
-      return true;
+    if (index === -1) {
+      return false;
     }
 
-    return false;
+    Html5DashJS.hooks_[type] = Html5DashJS.hooks_[type].slice();
+    Html5DashJS.hooks_[type].splice(index, 1);
+
+    return true;
   }
 }
 
-Html5DashJS.initializationHooks_ = [];
+Html5DashJS.hooks_ = {};
 
 const canHandleKeySystems = function(source) {
   if (Html5DashJS.updateSourceData) {

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -58,7 +58,7 @@ class Html5DashJS {
       Html5DashJS.beforeInitialize(this.player, this.mediaPlayer_);
     }
 
-    Html5DashJS.beforeInitializeHooks_.forEach((hook) => {
+    Html5DashJS.initializationHooks_.forEach((hook) => {
       hook(this.player, this.mediaPlayer_);
     });
 
@@ -127,20 +127,40 @@ class Html5DashJS {
    * Registers a callback function to be called before the MediaPlayer is initialized.
    * Does not register duplicates
    *
-   * @param {Function} fn callback function to register
+   * @param {Function} hook callback function to register
    * @function registerInitializationHook
    */
-  static registerInitializationHook(fn) {
-    const index = Html5DashJS.beforeInitializeHooks_.indexOf(fn);
+  static registerInitializationHook(hook) {
+    const index = Html5DashJS.initializationHooks_.indexOf(hook);
 
-    if (index <= -1) {
+    if (index === -1) {
       // Only add callback if its not a duplicate
-      Html5DashJS.beforeInitializeHooks_.push(fn);
+      Html5DashJS.initializationHooks_ = Html5DashJS.initializationHooks_.concat(hook);
     }
+  }
+
+  /**
+   * Removes a registered callback function from the initialization hooks.
+   *
+   * @param {Function} hook callback function to remove
+   * @return {boolean} true if removed, false if callback not registered
+   * @function removeInitializationHook
+   */
+  static removeInitializationHook(hook) {
+    const index = Html5DashJS.initializationHooks_.indexOf(hook);
+
+    if (index !== -1) {
+      Html5DashJS.initializationHooks_ = Html5DashJS.initializationHooks_.slice();
+      Html5DashJS.initializationHooks_.splice(index, 1);
+
+      return true;
+    }
+
+    return false;
   }
 }
 
-Html5DashJS.beforeInitializeHooks_ = [];
+Html5DashJS.initializationHooks_ = [];
 
 const canHandleKeySystems = function(source) {
   if (Html5DashJS.updateSourceData) {

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -104,8 +104,7 @@
 
   q.module('videojs-dash dash.js SourceHandler', {
     afterEach: function() {
-      videojs.Html5DashJS.updateSourceData = undefined;
-      videojs.Html5DashJS.initializationHooks_.length = 0;
+      videojs.Html5DashJS.hooks_ = {};
       sampleSrc = {
         src: 'movie.mpd',
         type: 'application/dash+xml',
@@ -195,7 +194,7 @@
       }
     };
 
-    videojs.Html5DashJS.updateSourceData = function(source) {
+    var updateSourceData = function(source) {
       source.keySystemOptions = [{
         name: 'com.widevine.alpha',
         options: {
@@ -204,15 +203,17 @@
       }];
       return source;
     };
+    videojs.Html5DashJS.hook('updatesource', updateSourceData);
 
     testHandleSource(assert, sampleSrc, mergedKeySystemOptions);
   });
 
-  q.test('registers registerInitializationHook callbacks correctly', function(assert) {
+  q.test('registers hook callbacks correctly', function(assert) {
     var cb1Count = 0;
     var cb2Count = 0;
-    var cb1 = function() {
+    var cb1 = function(source) {
       cb1Count++;
+      return source;
     };
     var cb2 = function() {
       cb2Count++;
@@ -224,18 +225,17 @@
       }
     };
 
-    videojs.Html5DashJS.registerInitializationHook(cb1);
-    videojs.Html5DashJS.registerInitializationHook(cb2);
-    videojs.Html5DashJS.registerInitializationHook(cb1);
+    videojs.Html5DashJS.hook('updatesource', cb1);
+    videojs.Html5DashJS.hook('beforeinitialize', cb2);
 
     testHandleSource(assert, sampleSrc, mergedKeySystemOptions, true);
 
     assert.expect(9);
 
     assert.equal(cb1Count, 1,
-      'did not register duplicate callback, only called once during initialization');
+      'registered first callback and called');
     assert.equal(cb2Count, 1,
-      'registered second callback and called during initialization');
+      'registered second callback and called');
   });
 
   q.test('removes callbacks with removeInitializationHook correctly', function(assert) {
@@ -248,13 +248,16 @@
     };
     var cb2 = function() {
       cb2Count++;
-      assert.ok(videojs.Html5DashJS.removeInitializationHook(cb2), 'removed hook cb2');
+      assert.ok(videojs.Html5DashJS.removeHook('beforeinitialize', cb2),
+        'removed hook cb2');
     };
-    var cb3 = function() {
+    var cb3 = function(source) {
       cb3Count++;
+      return source;
     };
-    var cb4 = function() {
+    var cb4 = function(source) {
       cb4Count++;
+      return source;
     };
     var mergedKeySystemOptions = {
       'com.widevine.alpha': {
@@ -263,26 +266,30 @@
       }
     };
 
-    videojs.Html5DashJS.registerInitializationHook(cb1);
-    videojs.Html5DashJS.registerInitializationHook(cb2);
-    videojs.Html5DashJS.registerInitializationHook(cb3);
-    videojs.Html5DashJS.registerInitializationHook(cb4);
+    videojs.Html5DashJS.hook('beforeinitialize', [cb1, cb2]);
+    videojs.Html5DashJS.hook('updatesource', [cb3, cb4]);
 
-    assert.equal(videojs.Html5DashJS.initializationHooks_.length, 4, 'added 4 hooks');
+    assert.equal(videojs.Html5DashJS.hooks('beforeinitialize').length, 2,
+      'added 2 hooks to beforeinitialize');
+    assert.equal(videojs.Html5DashJS.hooks('updatesource').length, 2,
+      'added 2 hooks to updatesource');
 
-    assert.ok(videojs.Html5DashJS.removeInitializationHook(cb3), 'removed hook cb3');
+    assert.ok(!videojs.Html5DashJS.removeHook('beforeinitialize', cb3),
+      'nothing removed if callback not found');
+    assert.ok(videojs.Html5DashJS.removeHook('updatesource', cb3), 'removed cb3');
 
-    assert.equal(videojs.Html5DashJS.initializationHooks_.length, 3, 'removed hook cb3');
+    assert.equal(videojs.Html5DashJS.hooks('updatesource').length, 1, 'removed hook cb3');
 
     testHandleSource(assert, sampleSrc, mergedKeySystemOptions, true);
 
-    assert.expect(16);
+    assert.expect(18);
 
     assert.equal(cb1Count, 1, 'called cb1');
     assert.equal(cb2Count, 1, 'called cb2');
     assert.equal(cb3Count, 0, 'did not call cb3');
     assert.equal(cb4Count, 1, 'called cb4');
-    assert.equal(videojs.Html5DashJS.initializationHooks_.length, 2, 'cb2 removed itself');
+    assert.equal(videojs.Html5DashJS.hooks('beforeinitialize').length, 1,
+      'cb2 removed itself');
   });
 
 })(window, window.videojs, window.dashjs, window.QUnit);

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -208,7 +208,7 @@
     testHandleSource(assert, sampleSrc, mergedKeySystemOptions);
   });
 
-  q.test('registers beforeInitialize callbacks correctly', function(assert) {
+  q.test('registers registerInitializationHook callbacks correctly', function(assert) {
     var cb1Count = 0;
     var cb2Count = 0;
     var cb1 = function() {
@@ -224,9 +224,9 @@
       }
     };
 
-    videojs.Html5DashJS.beforeInitialize(cb1);
-    videojs.Html5DashJS.beforeInitialize(cb2);
-    videojs.Html5DashJS.beforeInitialize(cb1);
+    videojs.Html5DashJS.registerInitializationHook(cb1);
+    videojs.Html5DashJS.registerInitializationHook(cb2);
+    videojs.Html5DashJS.registerInitializationHook(cb1);
 
     testHandleSource(assert, sampleSrc, mergedKeySystemOptions, true);
 


### PR DESCRIPTION
Currently,  you have to overwrite `beforeInitialize` for your custom initialization code to run. This can be a problem if multiple plugins want to run initialization code.

This change makes `beforeInitialize` a static api for registering a callback into a list, which will be iterated through and each function called during initialization.