### PR TITLE
Load text tracks from dash into video.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ var updateSourceData = function(source) {
 videojs.Html5DashJS.hook('updatesource', updateSourceData);
 ```
 
+## Captions
+
+As of `video.js@5.14`, native captions are no longer supported on any browser besides Safari. Dash can handle captions referenced embedded vtt files, embedded captions in the manifest, and with fragmented text streaming. It is impossible to use video.js captions when dash.js is using fragmented text captions, so the user must disable native captions when using `videojs-contrib-dash`.
+
+```javascript
+videojs('example-video', {
+  html5: {
+    nativeCaptions: false
+  }
+});
+```
+
+A warning will be logged if this setting is not applied.
+
 ## Passing options to Dash.js
 
 It is possible to pass options to Dash.js during initialiation of video.js. All methods in the [`Dash.js#MediaPlayer` docs](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html) are supported.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "dashjs": "^2.2.0",
     "global": "^4.3.0",
-    "video.js": "^5.0.0"
+    "video.js": "^5.18.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -1,0 +1,167 @@
+import dashjs from 'dashjs';
+import videojs from 'video.js';
+
+/*
+ * Attach text tracks from dash.js to videojs
+ *
+ * @param {videojs} player the videojs player instance
+ * @param {array} tracks the tracks loaded by dash.js to attach to videojs
+ *
+ * @private
+ */
+function attachDashTextTracksToVideojs(player, tech, tracks) {
+  const trackDictionary = [];
+
+  // Add remote tracks
+  const tracksAttached = tracks
+    // Map input data to match HTMLTrackElement spec
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLTrackElement
+    .map((track) => ({
+      dashTrack: track,
+      trackConfig: {
+        default: track.defaultTrack,
+        kind: track.kind,
+        label: track.lang,
+        language: track.lang,
+        srclang: track.lang,
+      },
+    }))
+
+    // Add track to videojs track list
+    .map(({trackConfig, dashTrack}) => {
+      const remoteTextTrack = player.addRemoteTextTrack(trackConfig, true);
+      trackDictionary.push({textTrack: remoteTextTrack.track, dashTrack});
+
+      // Don't add the cues becuase we're going to let dash handle it natively. This will ensure
+      // that dash handle external time text files and fragmented text tracks.
+      //
+      // Example file with external time text files:
+      // https://storage.googleapis.com/shaka-demo-assets/sintel-mp4-wvtt/dash.mpd
+
+      return remoteTextTrack;
+    })
+  ;
+
+  /*
+   * Scan `videojs.textTracks()` to find one that is showing. Set the dash text track.
+   */
+  function updateActiveDashTextTrack() {
+    const dashMediaPlayer = player.dash.mediaPlayer;
+    const textTracks = player.textTracks();
+    let activeTextTrackIndex = -1;
+
+    // Iterate through the tracks and find the one marked as showing. If none are showing,
+    // `activeTextTrackIndex` will be set to `-1`, disabling text tracks.
+    for (let i = 0; i < textTracks.length; i += 1) {
+      const textTrack = textTracks[i];
+
+      if (textTrack.mode === 'showing') {
+        // Find the dash track we want to use
+
+        const dictionaryLookupResult = trackDictionary.find(
+          /* jshint loopfunc: true */
+          ({textTrack: dictionaryTextTrack}) => dictionaryTextTrack === textTrack
+          /* jshint loopfunc: false */
+        );
+
+        const dashTrackToActivate = dictionaryLookupResult ?
+          dictionaryLookupResult.dashTrack :
+          null;
+
+        // If we found a track, get it's index.
+        if (dashTrackToActivate) {
+          activeTextTrackIndex = tracks.indexOf(dashTrackToActivate);
+        }
+      }
+    }
+
+    // If the text track has changed, then set it in dash
+    if (activeTextTrackIndex !== dashMediaPlayer.getCurrentTextTrackIndex()) {
+      dashMediaPlayer.setTextTrack(activeTextTrackIndex);
+    }
+  }
+
+  // Initialize the text track on our first run-through
+  updateActiveDashTextTrack();
+
+  // Update dash when videojs's selected text track changes.
+  player.textTracks().on('change', updateActiveDashTextTrack);
+
+  // Cleanup event listeners whenever we start loading a new source
+  player.one('loadstart', () => {
+    player.textTracks().off('change', updateActiveDashTextTrack);
+  });
+
+  /*
+   * Now that all the text tracks are created, iterate through them and set the default to
+   * `showing`. Note that more than one track can be listed as a default because this will create
+   * subtitles and captions which can independently have their own defaults.
+  */
+  const textTracks = player.textTracks();
+
+  for (let i = 0; i < textTracks.length; i += 1) {
+    const textTrack = textTracks[i];
+    textTrack.mode = textTrack.default ? 'showing' : 'hidden';
+  }
+
+  return tracksAttached;
+}
+
+/*
+ * Wait for dash to emit `TEXT_TRACKS_ADDED` and then attach the text tracks loaded by dash if
+ * we're not using native text tracks.
+ *
+ * @param {videojs} player the videojs player instance
+ * @private
+ */
+export default function setupTextTracks(player, tech, options) {
+  // Store the tracks that we've added so we can remove them later.
+  let dashTracksAttachedToVideoJs = [];
+
+  // We're relying on the user to disable native captions. Show an error if they didn't do so.
+  if (tech.featuresNativeTextTracks) {
+    videojs.log.error('You must pass {html: {nativeCaptions: false}} in the videojs constructor ' +
+      'to use text tracks in videojs-contrib-dash');
+    return;
+  }
+
+  const mediaPlayer = player.dash.mediaPlayer;
+
+  // Clear the tracks that we added. We don't clear them all because someone else can add tracks.
+  function clearDashTracks() {
+    dashTracksAttachedToVideoJs.forEach(player.removeRemoteTextTrack.bind(player));
+
+    dashTracksAttachedToVideoJs = [];
+  }
+
+  function handleTextTracksAdded({index, tracks}) {
+    // Stop listening for this event. We only want to hear it once.
+    mediaPlayer.off(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
+
+    // Cleanup old tracks
+    clearDashTracks();
+
+    if (!tracks.length) {
+      // Don't try to add text tracks if there aren't any
+      return;
+    }
+
+    // Save the tracks so we can remove them later
+    dashTracksAttachedToVideoJs = attachDashTextTracksToVideojs(player, tech, tracks, options);
+  }
+
+  // Attach dash text tracks whenever we dash emits `TEXT_TRACKS_ADDED`.
+  mediaPlayer.on(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
+
+  function cleanup() {
+    mediaPlayer.off(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
+
+    player.one('loadstart', clearDashTracks);
+  }
+
+  // When the player can play, remove the initialization events. We might not have received
+  // TEXT_TRACKS_ADDED` so we have to stop listening for it or we'll get errors when we load new
+  // videos and are listening for the same event in multiple places, including cleaned up
+  // mediaPlayers.
+  mediaPlayer.on(dashjs.MediaPlayer.events.CAN_PLAY, cleanup);
+}

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -81,9 +81,6 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
     }
   }
 
-  // Initialize the text track on our first run-through
-  updateActiveDashTextTrack();
-
   // Update dash when videojs's selected text track changes.
   player.textTracks().on('change', updateActiveDashTextTrack);
 
@@ -95,14 +92,22 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
   /*
    * Now that all the text tracks are created, iterate through them and set the default to
    * `showing`. Note that more than one track can be listed as a default because this will create
-   * subtitles and captions which can independently have their own defaults.
+   * subtitles and captions which can independently have their own defaults. This will ignore all
+   * tracks that are not `subtitles` or `captions`, otherwise we'll be showing text data for
+   * `metadata` and `descriptions` tracks.
   */
   const textTracks = player.textTracks();
 
   for (let i = 0; i < textTracks.length; i += 1) {
     const textTrack = textTracks[i];
-    textTrack.mode = textTrack.default ? 'showing' : 'hidden';
+
+    if (textTrack.kind === 'subtitles' || textTrack.kind === 'captions') {
+      textTrack.mode = textTrack.default ? 'showing' : 'hidden';
+    }
   }
+
+  // Initialize the text track on our first run-through
+  updateActiveDashTextTrack();
 
   return tracksAttached;
 }

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -2,6 +2,7 @@ import window from 'global/window';
 import videojs from 'video.js';
 import dashjs from 'dashjs';
 import setupAudioTracks from './setup-audio-tracks';
+import setupTextTracks from './setup-text-tracks';
 
 let
   isArray = function(a) {
@@ -113,6 +114,9 @@ class Html5DashJS {
 
     // Setup audio tracks
     setupAudioTracks.call(null, this.player, tech);
+
+    // Setup text tracks
+    setupTextTracks.call(null, this.player, tech, options);
 
     // Attach the source with any protection data
     this.mediaPlayer_.setProtectionData(this.keySystemOptions_);


### PR DESCRIPTION
As of video.js v5.14, video.js no longer supports native subtitles on anything besides Safari. For Chrome, this means there is *no* subtitle support. This will wait for dash.js to load all the text tracks and then add them to video.js if we're using a version that does not attempt to use native subtitles. Audio tracks will also be added.


---

## Todo

- [x] Replace`.map` with `.forEach` https://github.com/videojs/videojs-contrib-dash/pull/135#pullrequestreview-18056224
- [x] Remove `WeakMap` https://github.com/videojs/videojs-contrib-dash/pull/135#pullrequestreview-18287005
- [x] Make sure to clean everything up when source is changed. See https://github.com/videojs/videojs-contrib-media-sources/pull/118#pullrequestreview-8644856
- [x] Don't use `Map`
- [x] Fix Safari
- [x] Update README.md
- [x] [Audio tracks looks good to me but I'm not seeing the text track cues populate for http://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd
](https://github.com/videojs/videojs-contrib-dash/pull/135#issuecomment-277347876)
- [x] ~~[Location for `automaticTextTrackSelection ` option](https://github.com/videojs/videojs-contrib-dash/pull/135#discussion_r99416456)~~

---

~~Wait for https://github.com/videojs/video.js/pull/4131 to be merged. Add that version as an explicit dependency (maybe change it to a `peerDependency` and `devDependency` since we don't actually need it here?~~

This fix depends on videojs@^v5.18