### PR TITLE
Support all dash.js configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,9 @@ videojs.Html5DashJS.hook('updatesource', updateSourceData);
 
 ## Passing options to Dash.js
 
-It is possible to pass options to Dash.js during initialiation of video.js. The following options are currently supported:
+It is possible to pass options to Dash.js during initialiation of video.js. All methods prefixed with `set` in the [`Dash.js#MediaPlayer` docs](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html) are supported.
 
-* `limitBitrateByPortal` (defaults to `false`): if set to `true`, Dash.js will not request video tracks which are bigger than the video element.
-
-To set these options, pass them in the `html5.dash` object of video.js during initialization.
+To set these options, pass the property name you wish to call the setter on in the `html5.dash` object of video.js during initialization.
 
 For example:
 
@@ -96,6 +94,10 @@ var player = videojs('example-video', {
   }
 });
 ```
+
+This will call [`mediaPlayer.setLimitBitrateByPortal(true)`](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html#setLimitBitrateByPortal__anchor) after initialization.
+
+A warning will be logged with Dash.js if the configuration property is not found.
 
 ## Initialization Hook
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -73,11 +73,18 @@ class Html5DashJS {
     // element to bind to.
     this.mediaPlayer_.initialize();
 
-    // Apply any options that are set
-    if (options.dash && options.dash.limitBitrateByPortal) {
-      this.mediaPlayer_.setLimitBitrateByPortal(true);
-    } else {
-      this.mediaPlayer_.setLimitBitrateByPortal(false);
+    // Apply all dash options that are set
+    if (options.dash) {
+      Object.keys(options.dash).forEach((key) => {
+        const dashOptionsKey = 'set' + key.charAt(0).toUpperCase() + key.slice(1);
+        if (this.mediaPlayer_.hasOwnProperty(dashOptionsKey)) {
+          this.mediaPlayer_[dashOptionsKey](options.dash[key]);
+        } else {
+          this.mediaPlayer_.getDebug().log(
+            `Warning: dash configuration option unrecognized: ${key}`
+          );
+        }
+      });
     }
 
     this.mediaPlayer_.attachView(this.el_);


### PR DESCRIPTION
Allow all configuration options that dash.js supports to be passed at instantiation.

I updated the README.md, but I think my wording is confusing. Can someone please suggest a better way to describe what this does?

~~This will not work on IE8 because of `Object.keys` and `Array.prototype.forEach`. IE8 doesn't support dash anyway, so that shouldn't matter, right?~~

Todo:

- [x] Better wording for docs?
- [x] [~~Do we need the `Object.keys` and `Array.prototype.forEach` polyfills?~~](https://github.com/videojs/videojs-contrib-dash/pull/139#issuecomment-276092599)
- [x] [Support non-boolean options](https://github.com/videojs/videojs-contrib-dash/pull/139#discussion_r98466159)

Addresses #138 