### PR TITLE
Allow dash config object to accept setters with multiple args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ videojs.Html5DashJS.hook('updatesource', updateSourceData);
 
 ## Passing options to Dash.js
 
-It is possible to pass options to Dash.js during initialiation of video.js. All methods prefixed with `set` in the [`Dash.js#MediaPlayer` docs](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html) are supported.
+It is possible to pass options to Dash.js during initialiation of video.js. All methods in the [`Dash.js#MediaPlayer` docs](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html) are supported.
 
-To set these options, pass the property name you wish to call the setter on in the `html5.dash` object of video.js during initialization.
+To set these options, pass the exact function name with a scalar or array value to call the correpsonding MediaPlayer function.
 
 For example:
 
@@ -89,15 +89,18 @@ For example:
 var player = videojs('example-video', {
   html5: {
     dash: {
-      limitBitrateByPortal: true
+      setLimitBitrateByPortal: true
+      setMaxAllowedBitrateFor: ['video', 2000]
     }
   }
 });
 ```
 
-This will call [`mediaPlayer.setLimitBitrateByPortal(true)`](http://cdn.dashjs.org/latest/jsdoc/module-MediaPlayer.html#setLimitBitrateByPortal__anchor) after initialization.
+A warning will be logged if the configuration property is not found.
 
-A warning will be logged with Dash.js if the configuration property is not found.
+### Deprecation Warning
+
+Previously the `set` prefix was expected to be omitted. This has been deprecated and will be removed in a future version.
 
 ## Initialization Hook
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -77,13 +77,31 @@ class Html5DashJS {
     if (options.dash) {
       Object.keys(options.dash).forEach((key) => {
         const dashOptionsKey = 'set' + key.charAt(0).toUpperCase() + key.slice(1);
+        let value = options.dash[key];
+
         if (this.mediaPlayer_.hasOwnProperty(dashOptionsKey)) {
-          this.mediaPlayer_[dashOptionsKey](options.dash[key]);
-        } else {
-          this.mediaPlayer_.getDebug().log(
+          // Providing a key without `set` prefix is now deprecated.
+          videojs.log.warn(`Using dash options in videojs-contrib-dash without the set prefix ` +
+            `has been deprecated. Change '${key}' to '${dashOptionsKey}'`);
+
+          // Set key so it will still work
+          key = dashOptionsKey;
+        }
+
+        if (!this.mediaPlayer_.hasOwnProperty(key)) {
+          videojs.log.warn(
             `Warning: dash configuration option unrecognized: ${key}`
           );
+
+          return;
         }
+
+        // Guarantee `value` is an array
+        if (!isArray(value)) {
+          value = [value];
+        }
+
+        this.mediaPlayer_[key](...value);
       });
     }
 


### PR DESCRIPTION
Allow multiple parameters for dash object configuration and require literal function from dash.js MediaPlayer.

The following will work as expected:

```javascript
videojs(
  document.querySelector( ... ), 
  {
    html5: {
      dash: {
        setLimitBitrateByPortal: true,
        setMaxAllowedBitrateFor: ['video', 2000]
      }
    }
  }
);
```

This deprecates passing a property name like `limitBitrateByPortal` and will log a warning with `videojs.log.warn()`.

---

- [x] Fix issue
- [x] Update README.md

---

Fixes #143 