### PR TITLE
Fix typo dash.js options example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For example:
 var player = videojs('example-video', {
   html5: {
     dash: {
-      setLimitBitrateByPortal: true
+      setLimitBitrateByPortal: true,
       setMaxAllowedBitrateFor: ['video', 2000]
     }
   }


### PR DESCRIPTION
Added a missing comma per https://github.com/videojs/videojs-contrib-dash/pull/144#issuecomment-277088974

Caused by #144