### PR TITLE
Fix dashjs text tracks for IE

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [ "es3", ["es2015", {"loose": true}]]
+}

--- a/package.json
+++ b/package.json
@@ -59,8 +59,10 @@
     "video.js": "^5.18.0"
   },
   "devDependencies": {
-    "babel": "^5.8.0",
-    "babelify": "^6.0.0",
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-es3": "^1.0.1",
+    "babelify": "^7.3.0",
     "bannerize": "^1.0.0",
     "browserify": "^11.0.0",
     "browserify-shim": "^3.0.0",

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -19,8 +19,6 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
     .map((track) => ({
       dashTrack: track,
       trackConfig: {
-        default: track.defaultTrack,
-        kind: track.kind,
         label: track.lang,
         language: track.lang,
         srclang: track.lang,
@@ -88,23 +86,6 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
   player.one('loadstart', () => {
     player.textTracks().off('change', updateActiveDashTextTrack);
   });
-
-  /*
-   * Now that all the text tracks are created, iterate through them and set the default to
-   * `showing`. Note that more than one track can be listed as a default because this will create
-   * subtitles and captions which can independently have their own defaults. This will ignore all
-   * tracks that are not `subtitles` or `captions`, otherwise we'll be showing text data for
-   * `metadata` and `descriptions` tracks.
-  */
-  const textTracks = player.textTracks();
-
-  for (let i = 0; i < textTracks.length; i += 1) {
-    const textTrack = textTracks[i];
-
-    if (textTrack.kind === 'subtitles' || textTrack.kind === 'captions') {
-      textTrack.mode = textTrack.default ? 'showing' : 'hidden';
-    }
-  }
 
   // Initialize the text track on our first run-through
   updateActiveDashTextTrack();

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -1,6 +1,14 @@
 import dashjs from 'dashjs';
 import videojs from 'video.js';
 
+function find(l, f) {
+  for(let i = 0; i < l.length; i++) {
+    if (f(l[i])) {
+      return l[i];
+    }
+  }
+}
+
 /*
  * Attach text tracks from dash.js to videojs
  *
@@ -56,11 +64,10 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
       if (textTrack.mode === 'showing') {
         // Find the dash track we want to use
 
-        const dictionaryLookupResult = trackDictionary.find(
-          /* jshint loopfunc: true */
-          ({textTrack: dictionaryTextTrack}) => dictionaryTextTrack === textTrack
-          /* jshint loopfunc: false */
-        );
+        /* jshint loopfunc: true */
+        const dictionaryLookupResult = find(trackDictionary,
+          ({textTrack: dictionaryTextTrack}) => dictionaryTextTrack === textTrack);
+        /* jshint loopfunc: false */
 
         const dashTrackToActivate = dictionaryLookupResult ?
           dictionaryLookupResult.dashTrack :

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -66,7 +66,7 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
 
         /* jshint loopfunc: true */
         const dictionaryLookupResult = find(trackDictionary,
-          ({textTrack: dictionaryTextTrack}) => dictionaryTextTrack === textTrack);
+          (track) => track.textTrack === textTrack);
         /* jshint loopfunc: false */
 
         const dashTrackToActivate = dictionaryLookupResult ?

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -111,7 +111,7 @@ export default function setupTextTracks(player, tech, options) {
   // Clear VTTCue if it was shimmed by vttjs and let dash.js use TextTrackCue.
   // This is necessary because dash.js creates text tracks
   // using addTextTrack which is incompatible with vttjs.VTTCue in IE11
-  if (!(/\[native code\]/).test(window.VTTCue.toString())) {
+  if (window.VTTCue && !(/\[native code\]/).test(window.VTTCue.toString())) {
     window.VTTCue = false;
   }
 

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -108,6 +108,13 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
  * @private
  */
 export default function setupTextTracks(player, tech, options) {
+  // Clear VTTCue if it was shimmed by vttjs and let dash.js use TextTrackCue.
+  // This is necessary because dash.js creates text tracks
+  // using addTextTrack which is incompatible with vttjs.VTTCue in IE11
+  if (!(/\[native code\]/).test(window.VTTCue.toString())) {
+    window.VTTCue = false;
+  }
+
   // Store the tracks that we've added so we can remove them later.
   let dashTracksAttachedToVideoJs = [];
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -4,11 +4,6 @@ import dashjs from 'dashjs';
 import setupAudioTracks from './setup-audio-tracks';
 import setupTextTracks from './setup-text-tracks';
 
-let
-  isArray = function(a) {
-    return Object.prototype.toString.call(a) === '[object Array]';
-  };
-
 /**
  * videojs-contrib-dash
  *
@@ -99,7 +94,7 @@ class Html5DashJS {
         }
 
         // Guarantee `value` is an array
-        if (!isArray(value)) {
+        if (!Array.isArray(value)) {
           value = [value];
         }
 
@@ -134,7 +129,7 @@ class Html5DashJS {
   static buildDashJSProtData(keySystemOptions) {
     let output = {};
 
-    if (!keySystemOptions || !isArray(keySystemOptions)) {
+    if (!keySystemOptions || !Array.isArray(keySystemOptions)) {
       return null;
     }
 


### PR DESCRIPTION
This change fixes some problems with captions in IE, makes all in-manifest captions of the 'subtitle' type and does not set the default in-manifest track to showing.