### PR TITLE
Retrigger dash.js errors on video.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Retrigger dash.js errors on video.js
 
 --------------------
 ## 2.9.2 (2017-10-11)

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -70,7 +70,7 @@ class Html5DashJS {
     // element to bind to.
     this.mediaPlayer_.initialize();
 
-    // Retrigger a dash.js-specific error event as a generic HTML5 one
+    // Retrigger a dash.js-specific error event as a player error
     // See src/streaming/utils/ErrorHandler.js in dash.js code
     // Handled with error (playback is stopped):
     // - capabilityError
@@ -82,46 +82,68 @@ class Html5DashJS {
     // - timedTextError (video can still play)
     // - mediaKeyMessageError (only fires under 'might not work' circumstances)
     this.retriggerError_ = (event) => {
-      // No support for MSE
-      if ((event.error === 'capability' && event.event === 'mediasource') ||
-        // Manifest type not supported
-        (event.error === 'manifestError' && event.event.id === 'createParser') ||
-        // Codec(s) not supported
-        (event.error === 'manifestError' && event.event.id === 'codec') ||
-        // No streams available to stream
-        (event.error === 'manifestError' && event.event.id === 'nostreams') ||
-        // not sure about this one
-        (event.error === 'manifestError' && event.event.id === 'nostreamscomposed') ||
-        // syntax error parsing the manifest
-        (event.error === 'manifestError' && event.event.id === 'parse') ||
-        // streams are multiplexed, which is not supported by dash
-        (event.error === 'manifestError' && event.event.id === 'multiplexedrep')) {
-        this.player.error({code: 4});
+      if (event.error === 'capability' && event.event === 'mediasource') {
+        // No support for MSE
+        this.player.error({
+          code: 4,
+          message: 'The media cannot be played because it requires a feature ' +
+            'that your browser does not support.'
+        });
+
+      } else if (event.error === 'manifestError' && (
+          (event.event.id === 'createParser') || // Manifest type not supported
+          (event.event.id === 'codec') || // Codec(s) not supported
+          (event.event.id === 'nostreams') || // No streams available to stream
+          (event.event.id === 'nostreamscomposed') || // Error creating Stream object
+          (event.event.id === 'parse') || // syntax error parsing the manifest
+          (event.event.id === 'multiplexedrep') // a stream has multiplexed audio+video
+        )) {
+        // These errors have useful error messages, so we forward it on
+        this.player.error({code: 4, message: event.event.message});
 
       } else if (event.error === 'mediasource') {
-        if (event.event === 'MEDIA_ERR_ABORTED') {
-          this.player.error({code: 1});
-        } else if (event.event === 'MEDIA_ERR_NETWORK') {
-          this.player.error({code: 2});
-        } else if (event.event === 'MEDIA_ERR_DECODE') {
-          this.player.error({code: 3});
-        } else if (event.event === 'MEDIA_ERR_SRC_NOT_SUPPORTED') {
-          this.player.error({code: 4});
-        } else if (event.event === 'MEDIA_ERR_ENCRYPTED') {
-          this.player.error({code: 5});
+        // This error happens when dash.js fails to allocate a SourceBuffer
+        // OR the underlying video element throws a `MediaError`.
+        // If it's a buffer allocation fail, the message states which buffer
+        // (audio/video/text) failed allocation.
+        // If it's a `MediaError`, dash.js inspects the error object for
+        // additional information to append to the error type.
+        if (event.event.match('MEDIA_ERR_ABORTED')) {
+          this.player.error({code: 1, message: event.event});
+        } else if (event.event.match('MEDIA_ERR_NETWORK')) {
+          this.player.error({code: 2, message: event.event});
+        } else if (event.event.match('MEDIA_ERR_DECODE')) {
+          this.player.error({code: 3, message: event.event});
+        } else if (event.event.match('MEDIA_ERR_SRC_NOT_SUPPORTED')) {
+          this.player.error({code: 4, message: event.event});
+        } else if (event.event.match('MEDIA_ERR_ENCRYPTED')) {
+          this.player.error({code: 5, message: event.event});
         } else {
-          this.player.error({
-            code: 4,
-            message: event.event
-          });
+          this.player.error({code: 4, message: event.event});
         }
 
-      } else if ((event.error === 'capability' && event.event === 'encryptedmedia') ||
-        (event.error === 'key_session')) {
-        this.player.error({code: 5});
+      } else if (event.error === 'capability' && event.event === 'encryptedmedia') {
+        // Browser doesn't support EME
+        this.player.error({
+          code: 5,
+          message: 'The media cannot be played because it requires encryption ' +
+            'features that your browser does not support.'
+        });
+
+      } else if (event.error === 'key_session') {
+        // This block handles pretty much all errors thrown by the
+        // encryption subsystem
+        this.player.error({
+          code: 5,
+          message: event.event
+        });
 
       } else if (event.error === 'download') {
-        this.player.error({code: 2});
+        this.player.error({
+          code: 2,
+          message: 'The media playback was aborted because too many consecutive ' +
+            'download errors occurred.'
+        });
 
       } else {
         // ignore the error

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -118,7 +118,15 @@ class Html5DashJS {
           this.player.error({code: 4, message: event.event});
         } else if (event.event.match('MEDIA_ERR_ENCRYPTED')) {
           this.player.error({code: 5, message: event.event});
+        } else if (event.event.match('UNKNOWN')) {
+          // We shouldn't ever end up here, since this would mean a
+          // `MediaError` thrown by the video element that doesn't comply
+          // with the W3C spec. But, since we should handle the error,
+          // throwing a MEDIA_ERR_SRC_NOT_SUPPORTED is probably the
+          // most reasonable thing to do.
+          this.player.error({code: 4, message: event.event});
         } else {
+          // Buffer allocation error
           this.player.error({code: 4, message: event.event});
         }
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -72,7 +72,7 @@ class Html5DashJS {
 
     // Retrigger a dash.js-specific error event as a generic HTML5 one
     // See src/streaming/utils/ErrorHandler.js in dash.js code
-    this.retriggerError = (event) => {
+    this.retriggerError_ = (event) => {
       this.player.pause();
       if (event.error === 'capability' && event.event === 'mediasource') {
         this.player.error({code: 4});
@@ -83,7 +83,7 @@ class Html5DashJS {
       }
     };
 
-    this.mediaPlayer_.on(dashjs.MediaPlayer.events.ERROR, this.retriggerError);
+    this.mediaPlayer_.on(dashjs.MediaPlayer.events.ERROR, this.retriggerError_);
 
     // Apply all dash options that are set
     if (options.dash) {
@@ -165,7 +165,7 @@ class Html5DashJS {
 
   dispose() {
     if (this.mediaPlayer_) {
-      this.mediaPlayer_.off(dashjs.MediaPlayer.events.ERROR, this.retriggerError);
+      this.mediaPlayer_.off(dashjs.MediaPlayer.events.ERROR, this.retriggerError_);
       this.mediaPlayer_.reset();
     }
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -70,6 +70,21 @@ class Html5DashJS {
     // element to bind to.
     this.mediaPlayer_.initialize();
 
+    // Retrigger a dash.js-specific error event as a generic HTML5 one
+    // See src/streaming/utils/ErrorHandler.js in dash.js code
+    this.retriggerError = (event) => {
+      this.player.pause();
+      if (event.error === 'capability' && event.event === 'mediasource') {
+        this.player.error({code: 4});
+      } else if (event.error === 'capability' && event.event === 'encryptedmedia') {
+        this.player.error({code: 5});
+      } else if (event.error === 'download') {
+        this.player.error({code: 2});
+      }
+    };
+
+    this.mediaPlayer_.on(dashjs.MediaPlayer.events.ERROR, this.retriggerError);
+
     // Apply all dash options that are set
     if (options.dash) {
       Object.keys(options.dash).forEach((key) => {
@@ -150,6 +165,7 @@ class Html5DashJS {
 
   dispose() {
     if (this.mediaPlayer_) {
+      this.mediaPlayer_.off(dashjs.MediaPlayer.events.ERROR, this.retriggerError);
       this.mediaPlayer_.reset();
     }
 

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -18,11 +18,11 @@
       type: 'application/dash+xml'
     },
 
-    testHandleSource = function(assert, source, expectedKeySystemOptions, testData) {
-      if (testData === undefined) {
-        testData = {};
+    testHandleSource = function(assert, source, expectedKeySystemOptions, config) {
+      if (config === undefined) {
+        config = {};
       }
-      var eventHandlers = (testData.eventHandlers !== undefined) ? testData.eventHandlers : {};
+      var eventHandlers = config.eventHandlers ? config.eventHandlers : {};
       var
         startupCalled = false,
         attachViewCalled = false,
@@ -41,7 +41,7 @@
       assert.expect(7);
 
       // Default limitBitrateByPortal to false
-      var limitBitrateByPortal = testData.limitBitrateByPortal || false;
+      var limitBitrateByPortal = config.limitBitrateByPortal || false;
 
       el.setAttribute('id', 'test-vid');
       fixture.appendChild(el);
@@ -106,7 +106,7 @@
                 eventHandlers[event].push(fn);
               },
 
-              reset: testData.resetCallback,
+              reset: config.resetCallback,
 
               trigger: function(event, data) {
                 if (!eventHandlers[event]) {
@@ -391,8 +391,12 @@
         trigger: {code: 5, message: 'MEDIA_ERR_ENCRYPTED: Some context'},
       },
       {
-        receive: {error: 'mediasource', event: 'Some unknown error'},
-        trigger: {code: 4, message: 'Some unknown error'},
+        receive: {error: 'mediasource', event: 'UNKNOWN: Some context'},
+        trigger: {code: 4, message: 'UNKNOWN: Some context'},
+      },
+      {
+        receive: {error: 'mediasource', event: 'Error creating video source buffer'},
+        trigger: {code: 4, message: 'Error creating video source buffer'},
       },
       {
         receive: {error: 'capability', event: 'encryptedmedia'},


### PR DESCRIPTION
Fixes videojs/video.js#4385.

I haven't added tests since stubbing out XHRs in dash.js is probably not very worthwhile with VHS coming along so quickly. But, I can if you really want.

One other thing: I'm not sure if this is the best way of doing it, but when I do class methods in ES6 syntax, I get no `this` inside, and `bind`ing the `this` makes the object hang around (at least in Chrome) on subsequent calls to `src`. I settled with using the `this.fn = () => {}` way of doing things since it got me the `this` and the object didn't hang around in memory.