### PR TITLE
use dynamic status of mpd for infinite duration

### DIFF
--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -255,11 +255,11 @@ class Html5DashJS {
   }
 
   duration() {
-    const duration = this.el_.duration;
-    if (duration === Number.MAX_VALUE) {
+    if (this.mediaPlayer_.isDynamic()) {
       return Infinity;
+    } else {
+      return this.mediaPlayer_.duration();
     }
-    return duration;
   }
 
   /**


### PR DESCRIPTION
When playing a live feed, dash.js sets the duration of the video to be quite large, but not `Number.MAX_VALUE`. Using the `MediaPlayer`'s `isDynamic` is probably a better choice for determining if the feed is live or not.