### PR TITLE
cleanup event handler addition/removal to not bork on source change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Cleanup of event addition and removal on dispose to not bork on source change
 
 --------------------
 ## 2.9.3 (2018-04-12)

--- a/src/js/setup-audio-tracks.js
+++ b/src/js/setup-audio-tracks.js
@@ -53,7 +53,7 @@ function handlePlaybackMetadataLoaded(player, tech) {
     );
   });
 
-  videojsAudioTracks.addEventListener('change', () => {
+  let audioTracksChangeHandler = () => {
     for (let i = 0; i < videojsAudioTracks.length; i++) {
       const track = videojsAudioTracks[i];
 
@@ -69,6 +69,11 @@ function handlePlaybackMetadataLoaded(player, tech) {
         continue;
       }
     }
+  };
+
+  videojsAudioTracks.addEventListener('change', audioTracksChangeHandler);
+  player.dash.mediaPlayer.on(dashjs.MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, () => {
+    videojsAudioTracks.removeEventListener('change', audioTracksChangeHandler);
   });
 }
 


### PR DESCRIPTION
The current way the event handlers are registered / unregistered for text and audio track changes causes problems when switching between `SourceHandler`s. This change seems to prevent it, at least from my testing with contrib-dash and contrib-hls.

There should probably be some automated tests here checking to make sure that's actually the case.