### PR TITLE
fix: pass the track kind to dashjs

### DIFF
--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -30,6 +30,7 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
         label: track.lang,
         language: track.lang,
         srclang: track.lang,
+        kind: track.kind
       },
     }))
 


### PR DESCRIPTION
If a captions track is present, it will be added as a `subtitles` kind track to video.js. 

You can reproduce this using: https://d2xk91j6i9s5cq.cloudfront.net/test/multi_subtitle_dash/02/presentation-static.mpd. This source has:
- one English captions track
- one English subtitles track
- one Spanish captions track
- one Spanish subtitles track