### PR TITLE
don't use sudo for installing software

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   # pulseaudio is needed for dockerized chrome since it has a dummy sink and
   # the dummy audio ALSA kernel module isn't loaded by Travis
   # libavcodec54 is needed by firefox for h.264 support
-  - sudo apt-get install --no-install-recommends pulseaudio libavcodec54
+  - apt-get install --no-install-recommends pulseaudio libavcodec54
   - pulseaudio -D
 env:
   matrix:


### PR DESCRIPTION
Obviously this should be the case since we specify `sudo: false`... not sure why I did that.