### PR TITLE
Fix travis config to actually use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,19 @@ cache:
 before_script:
   # always install the appropriate version of video.js for the environment
   - npm i "video.js@$VJS";
-  # pulseaudio is needed for dockerized chrome since it has a dummy sink and
-  # the dummy audio ALSA kernel module isn't loaded by Travis
-  # libavcodec54 is needed by firefox for h.264 support
-  - sudo apt-get install --no-install-recommends pulseaudio libavcodec54
   - pulseaudio -D
 env:
   matrix:
     - VJS=5
     - VJS=6
 addons:
+  apt:
+    # pulseaudio is needed for dockerized chrome since it has a dummy sink and
+    # the dummy audio ALSA kernel module isn't loaded by Travis
+    # libavcodec54 is needed by firefox for h.264 support
+    packages:
+      - pulseaudio
+      - libavcodec54
   chrome: stable
   firefox: latest
 


### PR DESCRIPTION
When I was testing how to get the tests running in the dockerized travis infra, I was running in the travis docker image as root. When moving to the actual travis config, it told me I needed to be root, so without thinking I added `sudo` to the front. I was sure they'd allow package installs, which they do, but only [using the apt addon](https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-on-Container-Based-Infrastructure); having `sudo` in the script [would automatically kick you over to the VM-based infra](https://docs.travis-ci.com/user/reference/overview/#For-a-particular-.travis.yml-configuration).

[Until they broke that yesterday.](https://github.com/travis-ci/travis-ci/issues/9875)

Anyway, now we'll actually be using the containerized infra.