### PR TITLE
docs: removing maintainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 A video.js source handler for supporting MPEG-DASH playback through a video.js player on browsers with support for Media Source Extensions.
 
-Lead Maintainer: Joe Forbes [forbesjo](https://github.com/forbesjo)
-
 Maintenance Status: Stable
 
 Drop by our slack channel (#playback) on the [Video.js slack](http://slack.videojs.com).


### PR DESCRIPTION
## Description
Removing the maintainers section since the video.js playback team maintains this repo