### PR TITLE
fix bug in vtt captions not showing (closes #307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+## Unreleased
+* Fix bug where VTT captions wouldn't show
+
 ## 2.10.1 (2018-12-18)
 * Change main to be `dist/videojs-dash.cjs.js`
 * Reformat test code

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -52,6 +52,11 @@ class Html5DashJS {
 
     this.mediaPlayer_ = this.player.dash.mediaPlayer;
 
+    // For whatever reason, we need to call setTextDefaultEnabled(false) to get
+    // VTT captions to show, even though we're doing virtually the same thing
+    // in setup-text-tracks.js
+    this.mediaPlayer_.setTextDefaultEnabled(false);
+
     // Log MedaPlayer messages through video.js
     if (Html5DashJS.useVideoJSDebug) {
       videojs.log.warn('useVideoJSDebug has been deprecated.' +

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -31,6 +31,8 @@ const testHandleSource = function(assert, source, expectedKeySystemOptions, conf
   let attachViewCalled = false;
   let setLimitBitrateByPortalCalled = false;
   let setLimitBitrateByPortalValue = null;
+  let setTextDefaultEnabledCalled = false;
+  let setTextDefaultEnabledValue = null;
   const el = document.createElement('div');
   const fixture = document.querySelector('#qunit-fixture');
 
@@ -40,7 +42,7 @@ const testHandleSource = function(assert, source, expectedKeySystemOptions, conf
 
   const origVJSXHR = videojs.xhr;
 
-  assert.expect(7);
+  assert.expect(9);
 
   // Default limitBitrateByPortal to false
   const limitBitrateByPortal = config.limitBitrateByPortal || false;
@@ -89,6 +91,10 @@ const testHandleSource = function(assert, source, expectedKeySystemOptions, conf
               'MediaPlayer.setLimitBitrateByPortal was called');
             assert.strictEqual(setLimitBitrateByPortalValue, limitBitrateByPortal,
               'MediaPlayer.setLimitBitrateByPortal was called with the correct value');
+            assert.strictEqual(setTextDefaultEnabledCalled, true,
+              'MediaPlayer.setTextDefaultEnabled was called');
+            assert.strictEqual(setTextDefaultEnabledValue, false,
+              'MediaPlayer.setTextDefaultEnabled was called with the correct value');
             assert.strictEqual(startupCalled, true, 'MediaPlayer.startup was called');
             assert.strictEqual(attachViewCalled, true, 'MediaPlayer.attachView was called');
 
@@ -120,6 +126,11 @@ const testHandleSource = function(assert, source, expectedKeySystemOptions, conf
             eventHandlers[event].forEach(function(handler) {
               handler(data);
             });
+          },
+
+          setTextDefaultEnabled(value) {
+            setTextDefaultEnabledCalled = true;
+            setTextDefaultEnabledValue = value;
           }
 
         };
@@ -271,7 +282,7 @@ QUnit.test('registers hook callbacks correctly', function(assert) {
 
   testHandleSource(assert, sampleSrc, mergedKeySystemOptions, {limitBitrateByPortal: true});
 
-  assert.expect(9);
+  assert.expect(11);
 
   assert.equal(cb1Count, 2,
     'registered first callback and called');
@@ -323,7 +334,7 @@ QUnit.test('removes callbacks with removeInitializationHook correctly', function
 
   testHandleSource(assert, sampleSrc, mergedKeySystemOptions, {limitBitrateByPortal: true});
 
-  assert.expect(18);
+  assert.expect(20);
 
   assert.equal(cb1Count, 1, 'called cb1');
   assert.equal(cb2Count, 1, 'called cb2');
@@ -337,7 +348,7 @@ QUnit.test('attaches dash.js error handler', function(assert) {
   const eventHandlers = {};
   const sourceHandler = testHandleSource(assert, sampleSrcNoDRM, null, {eventHandlers});
 
-  assert.expect(8);
+  assert.expect(10);
   assert.equal(eventHandlers[dashjs.MediaPlayer.events.ERROR][0],
     sourceHandler.retriggerError_);
 });
@@ -439,7 +450,7 @@ QUnit.test('handles various errors', function(assert) {
   const sourceHandler = testHandleSource(assert, sampleSrcNoDRM, null,
     {eventHandlers, resetCallback});
 
-  assert.expect(7 + (errors.length * 2));
+  assert.expect(9 + (errors.length * 2));
 
   let i;
 
@@ -474,6 +485,6 @@ QUnit.test('ignores unknown errors', function(assert) {
     assert.notOk(resetCalled, 'MediaPlayer has not been reset');
     done();
   }, 20);
-  assert.expect(9);
+  assert.expect(11);
 });
 


### PR DESCRIPTION
## Description
See #307 for the back-and-forth. I'm not sure why, but for whatever reason us setting the text track index to -1 and calling `setTextDefaultEnabled(false)`, which sets the text track index to -1, do not result in the same behaviour. It must be a timing thing.

## Specific Changes proposed
Call `setTextDefaultEnabled(false)` before `initialize()` on the dash.js `mediaPlayer` instance.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
