### PR TITLE
fix(setup-audio-tracks): undefined property kind in dashTrack

### DIFF
--- a/src/js/setup-audio-tracks.js
+++ b/src/js/setup-audio-tracks.js
@@ -26,6 +26,37 @@ function handlePlaybackMetadataLoaded(player, tech) {
     );
   }
 
+  /**
+   * Determines the audio track type
+   *
+   * Specification reference:
+   *
+   * Dash @see https://dashif-documents.azurewebsites.net/DASH-IF-IOP/master/DASH-IF-IOP.html#ref-for-audio-adaptation-set%E2%91%A1
+   * Media Element @see https://html.spec.whatwg.org/multipage/media.html#dom-audiotrack-kind
+   *
+   * @param {Object} dashAudioTrack
+   *
+   * @return {string}
+   */
+  function determineAudioTrackKind(dashAudioTrack) {
+    const hasMain = dashAudioTrack.roles.includes('main');
+    const hasDescription = dashAudioTrack.accessibility.includes('description');
+
+    if (hasMain && !hasDescription) {
+      return 'main';
+    }
+
+    if (hasMain && hasDescription) {
+      return 'main-desc';
+    }
+
+    if (hasDescription) {
+      return 'descriptions';
+    }
+
+    return 'alternative';
+  }
+
   // Safari creates a single native `AudioTrack` (not `videojs.AudioTrack`) when loading. Clear all
   // automatically generated audio tracks so we can create them all ourself.
   if (videojsAudioTracks.length) {
@@ -69,7 +100,7 @@ function handlePlaybackMetadataLoaded(player, tech) {
       new videojs.AudioTrack({
         enabled: dashTrack === currentAudioTrack,
         id: generateIdFromTrackIndex(dashTrack.index),
-        kind: dashTrack.kind || 'main',
+        kind: determineAudioTrackKind(dashTrack),
         label,
         language: dashTrack.lang
       })


### PR DESCRIPTION
## Description

This PR fixes the use of the `kind` property which is `undefined` in the `dashTrack` object causing all audio tracks to have `kind` set to `main`.

## Specific Changes proposed

- adds a function to determine the `kind` according to the property `roles` and `accessibility` from the object `dashTrack` provided by `dash.js`.

### Note

This PR does not strictly follow the specification see [ref-for-audio-adaptation-set](https://dashif-documents.azurewebsites.net/DASH-IF-IOP/master/DASH-IF-IOP.html#ref-for-audio-adaptation-set%E2%91%A1):

> Clients SHALL consider there to be an implicit Role descriptor with the "Role" scheme and the value `main` if no explicitly defined Role descriptor with the "Role" scheme is present.


## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
