### PR TITLE
fix: VideoJS 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "dashjs": "^4.2.0",
     "global": "^4.3.2",
-    "video.js": "^5.18.0 || ^6 || ^7"
+    "video.js": "^5.18.0 || ^6 || ^7 || ^8" 
   },
   "devDependencies": {
     "@gkatsev/rollup-plugin-node-builtins": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test/"
   ],
   "dependencies": {
-    "dashjs": "^4.7.4",
+    "dashjs": "^5.0.3",
     "global": "^4.3.2",
     "video.js": "^5.18.0 || ^6 || ^7 || ^8"
   },

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "test/"
   ],
   "dependencies": {
-    "dashjs": "^4.2.0",
+    "dashjs": "^4.7.4",
     "global": "^4.3.2",
-    "video.js": "^5.18.0 || ^6 || ^7 || ^8" 
+    "video.js": "^5.18.0 || ^6 || ^7 || ^8"
   },
   "devDependencies": {
     "@gkatsev/rollup-plugin-node-builtins": "^2.1.4",
@@ -71,12 +71,12 @@
     "not-prerelease": "^1.0.1",
     "npm-merge-driver-install": "^2.0.1",
     "npm-run-all": "^4.1.5",
-    "rollup": "^0.66.0",
+    "rollup": "^2.79.2",
     "rollup-plugin-node-globals": "^1.4.0",
     "shx": "^0.3.2",
     "sinon": "^6.1.5",
     "videojs-generate-karma-config": "^5.0.1",
-    "videojs-generate-rollup-config": "~2.3.0",
+    "videojs-generate-rollup-config": "^7.0.2",
     "videojs-generator-verify": "^3.0.1",
     "videojs-standard": "~7.1.0"
   },

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -31,6 +31,21 @@ const options = {
         nodeGlobalsPlugin()
       ])
     };
+  },
+  babel() {
+    return {
+      babelHelpers: 'runtime',
+      skipPreflightCheck: true,
+      presets: [
+        ['@babel/preset-env', {
+          targets: {
+            esmodules: true
+          },
+          modules: false
+        }]
+      ],
+      plugins: ['@babel/plugin-transform-runtime']
+    };
   }
 };
 const config = generate(options);

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -8,13 +8,6 @@ const options = {
   input: 'src/js/videojs-dash.js',
   distName: 'videojs-dash',
   exportName: 'videojsDash',
-  externals(defaults) {
-    return {
-      browser: [...defaults.browser, 'dashjs'],
-      module: [...defaults.module, 'dashjs'],
-      test: [...defaults.test, 'dashjs']
-    };
-  },
   // stream and string_decoder are used by some modules
   plugins(defaults) {
     return {

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -8,6 +8,13 @@ const options = {
   input: 'src/js/videojs-dash.js',
   distName: 'videojs-dash',
   exportName: 'videojsDash',
+  externals(defaults) {
+    return {
+      browser: [...defaults.browser, 'dashjs'],
+      module: [...defaults.module, 'dashjs'],
+      test: [...defaults.test, 'dashjs']
+    };
+  },
   // stream and string_decoder are used by some modules
   plugins(defaults) {
     return {

--- a/src/js/setup-audio-tracks.js
+++ b/src/js/setup-audio-tracks.js
@@ -1,6 +1,5 @@
-import dashjs from 'dashjs';
 import videojs from 'video.js';
-
+import { MediaPlayer } from 'dashjs';
 /**
  * Setup audio tracks. Take the tracks from dash and add the tracks to videojs. Listen for when
  * videojs changes tracks and apply that to the dash player because videojs doesn't do this
@@ -94,7 +93,7 @@ function handlePlaybackMetadataLoaded(player, tech) {
   };
 
   videojsAudioTracks.addEventListener('change', audioTracksChangeHandler);
-  player.dash.mediaPlayer.on(dashjs.MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, () => {
+  player.dash.mediaPlayer.on(MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, () => {
     videojsAudioTracks.removeEventListener('change', audioTracksChangeHandler);
   });
 }
@@ -106,7 +105,7 @@ function handlePlaybackMetadataLoaded(player, tech) {
 export default function setupAudioTracks(player, tech) {
   // When `dashjs` finishes loading metadata, create audio tracks for `video.js`.
   player.dash.mediaPlayer.on(
-    dashjs.MediaPlayer.events.PLAYBACK_METADATA_LOADED,
+    MediaPlayer.events.PLAYBACK_METADATA_LOADED,
     handlePlaybackMetadataLoaded.bind(null, player, tech)
   );
 }

--- a/src/js/setup-audio-tracks.js
+++ b/src/js/setup-audio-tracks.js
@@ -59,7 +59,7 @@ function handlePlaybackMetadataLoaded(player, tech) {
       label = dashTrack.lang;
 
       if (dashTrack.roles && dashTrack.roles.length) {
-        label += ' (' + dashTrack.roles.join(', ') + ')';
+        label += ' (' + (dashTrack.roles.map((role)=>role.value)).join(', ') + ')';
       }
     }
 

--- a/src/js/setup-text-tracks.js
+++ b/src/js/setup-text-tracks.js
@@ -1,6 +1,6 @@
-import dashjs from 'dashjs';
 import videojs from 'video.js';
 import window from 'global/window';
+import { MediaPlayer } from 'dashjs';
 
 function find(l, f) {
   for (let i = 0; i < l.length; i++) {
@@ -126,7 +126,7 @@ function attachDashTextTracksToVideojs(player, tech, tracks) {
   player.textTracks().on('change', updateActiveDashTextTrack);
 
   // Cleanup event listeners whenever we start loading a new source
-  player.dash.mediaPlayer.on(dashjs.MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, () => {
+  player.dash.mediaPlayer.on(MediaPlayer.events.STREAM_TEARDOWN_COMPLETE, () => {
     player.textTracks().off('change', updateActiveDashTextTrack);
   });
 
@@ -172,7 +172,7 @@ export default function setupTextTracks(player, tech, options) {
 
   function handleTextTracksAdded({index, tracks}) {
     // Stop listening for this event. We only want to hear it once.
-    mediaPlayer.off(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
+    mediaPlayer.off(MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
 
     // Cleanup old tracks
     clearDashTracks();
@@ -187,13 +187,13 @@ export default function setupTextTracks(player, tech, options) {
   }
 
   // Attach dash text tracks whenever we dash emits `TEXT_TRACKS_ADDED`.
-  mediaPlayer.on(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
+  mediaPlayer.on(MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
 
   // When the player can play, remove the initialization events. We might not have received
   // TEXT_TRACKS_ADDED` so we have to stop listening for it or we'll get errors when we load new
   // videos and are listening for the same event in multiple places, including cleaned up
   // mediaPlayers.
-  mediaPlayer.on(dashjs.MediaPlayer.events.CAN_PLAY, () => {
-    mediaPlayer.off(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
+  mediaPlayer.on(MediaPlayer.events.CAN_PLAY, () => {
+    mediaPlayer.off(MediaPlayer.events.TEXT_TRACKS_ADDED, handleTextTracksAdded);
   });
 }

--- a/src/js/ttml-text-track-display.js
+++ b/src/js/ttml-text-track-display.js
@@ -105,7 +105,8 @@ class TTMLTextTrackDisplay extends Component {
    *        The function to call when `TextTrackDisplay` is ready.
    */
   constructor(player, options, ready) {
-    super(player, videojs.mergeOptions(options, {playerOptions: {}}), ready);
+    super(player, options);
+    this.ready(ready);
     const selects = player.getChild('TextTrackSettings').$$('select');
 
     for (let i = 0; i < selects.length; i++) {

--- a/src/js/ttml-text-track-display.js
+++ b/src/js/ttml-text-track-display.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import dashjs from 'dashjs';
+import { MediaPlayer } from 'dashjs';
 import window from 'global/window';
 
 const Component = videojs.getComponent('Component');
@@ -112,7 +112,7 @@ class TTMLTextTrackDisplay extends Component {
     for (let i = 0; i < selects.length; i++) {
       this.on(selects[i], 'change', this.updateStyle.bind(this));
     }
-    player.dash.mediaPlayer.on(dashjs.MediaPlayer.events.CAPTION_RENDERED,
+    player.dash.mediaPlayer.on(MediaPlayer.events.CAPTION_RENDERED,
       this.updateStyle.bind(this));
   }
 

--- a/src/js/ttml-text-track-display.js
+++ b/src/js/ttml-text-track-display.js
@@ -105,8 +105,7 @@ class TTMLTextTrackDisplay extends Component {
    *        The function to call when `TextTrackDisplay` is ready.
    */
   constructor(player, options, ready) {
-    super(player, options);
-    this.ready(ready);
+    super(player, videojs.mergeOptions(options, {playerOptions: {}}), ready);
     const selects = player.getChild('TextTrackSettings').$$('select');
 
     for (let i = 0; i < selects.length; i++) {

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -1,6 +1,6 @@
 import window from 'global/window';
 import videojs from 'video.js';
-import dashjs from 'dashjs';
+import { MediaPlayer } from 'dashjs';
 import setupAudioTracks from './setup-audio-tracks';
 import setupTextTracks from './setup-text-tracks';
 import document from 'global/document';
@@ -49,7 +49,7 @@ class Html5DashJS {
 
     this.keySystemOptions_ = Html5DashJS.buildDashJSProtData(source.keySystemOptions);
 
-    this.player.dash.mediaPlayer = dashjs.MediaPlayer().create();
+    this.player.dash.mediaPlayer = MediaPlayer().create();
 
     this.mediaPlayer_ = this.player.dash.mediaPlayer;
 
@@ -181,7 +181,7 @@ class Html5DashJS {
       }, 10);
     };
 
-    this.mediaPlayer_.on(dashjs.MediaPlayer.events.ERROR, this.retriggerError_);
+    this.mediaPlayer_.on(MediaPlayer.events.ERROR, this.retriggerError_);
 
     this.getDuration_ = (event) => {
       const periods = event.data.Period_asArray;
@@ -200,7 +200,7 @@ class Html5DashJS {
       }
     };
 
-    this.mediaPlayer_.on(dashjs.MediaPlayer.events.MANIFEST_LOADED, this.getDuration_);
+    this.mediaPlayer_.on(MediaPlayer.events.MANIFEST_LOADED, this.getDuration_);
 
     // Apply all dash options that are set
     if (options.dash) {
@@ -291,8 +291,8 @@ class Html5DashJS {
 
   dispose() {
     if (this.mediaPlayer_) {
-      this.mediaPlayer_.off(dashjs.MediaPlayer.events.ERROR, this.retriggerError_);
-      this.mediaPlayer_.off(dashjs.MediaPlayer.events.MANIFEST_LOADED, this.getDuration_);
+      this.mediaPlayer_.off(MediaPlayer.events.ERROR, this.retriggerError_);
+      this.mediaPlayer_.off(MediaPlayer.events.MANIFEST_LOADED, this.getDuration_);
       this.mediaPlayer_.reset();
     }
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -184,7 +184,7 @@ class Html5DashJS {
     this.mediaPlayer_.on(MediaPlayer.events.ERROR, this.retriggerError_);
 
     this.getDuration_ = (event) => {
-      const periods = event.data.Period_asArray;
+      const periods = event.data.Period;
       const oldHasFiniteDuration = this.hasFiniteDuration_;
 
       if (event.data.mediaPresentationDuration || periods[periods.length - 1].duration) {


### PR DESCRIPTION
## Description
Allow videojs 8 


## Specific Changes proposed

1. Added videojs 8 in dependency in package.json.
2. Updated `rollup` and `videojs-generate-rollup-config` versions.
3. Changes in rollup.config.js to avoid transpilation to es5.
4. Made it compatible with dashjs5.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
